### PR TITLE
Execute statements from commandline

### DIFF
--- a/docs/source/include/command-line.rst
+++ b/docs/source/include/command-line.rst
@@ -29,6 +29,12 @@ useful ones are listed below.
   RA session, which is especially useful for recording what you did in
   an interactive session.
 
+* Use ``-q`` (``--query``) *query_string* to specify an RA statement to execute.
+  If this parameter is provided radb will exit after evaluating this statement.
+
+* Use ``-f`` (``--outputformat``) *format* (one of ``radb``, ``org``,
+  ``markdown``) to select how results are shown.
+
 * The optional *source* argument (without a flag) specifies the data
   source you want to connect to.  It can be the name of a section in
   your user configuration file (under which RA can find detailed

--- a/docs/source/include/command-line.rst
+++ b/docs/source/include/command-line.rst
@@ -32,7 +32,7 @@ useful ones are listed below.
 * Use ``-q`` (``--query``) *query_string* to specify an RA statement to execute.
   If this parameter is provided radb will exit after evaluating this statement.
 
-* Use ``-f`` (``--outputformat``) *format* (one of ``radb``, ``org``,
+* Use ``-f`` (``--outputformat``) *format* (one of ``default``, ``org``,
   ``markdown``, ``csv``) to select how results are shown.
 
 * The optional *source* argument (without a flag) specifies the data

--- a/docs/source/include/command-line.rst
+++ b/docs/source/include/command-line.rst
@@ -33,7 +33,7 @@ useful ones are listed below.
   If this parameter is provided radb will exit after evaluating this statement.
 
 * Use ``-f`` (``--outputformat``) *format* (one of ``radb``, ``org``,
-  ``markdown``) to select how results are shown.
+  ``markdown``, ``csv``) to select how results are shown.
 
 * The optional *source* argument (without a flag) specifies the data
   source you want to connect to.  It can be the name of a section in

--- a/radb/ast.py
+++ b/radb/ast.py
@@ -6,7 +6,7 @@ from radb.utils import CustomJSONSerializable, lreplace
 from radb.typesys import ValType, AttrSpec, RelType, TypeSysError
 from radb.parse import RAParser as sym
 from radb.parse import literal, symbolic, sqlstr_to_str, str_to_sqlstr
-from radb.parse import statements_from_file, one_statement_from_string
+from radb.parse import statements_from_file, one_statement_from_string, statements_from_string
 
 import logging
 logger = logging.getLogger('ra')
@@ -33,7 +33,18 @@ class StatementContext(Context):
 ######################################################################
 
 def execute_from_file(filename, context, echo=False):
-    for ast in statements_from_file(filename):
+    execute_statements(statements_from_file(filename),
+                       context,
+                       echo)
+
+def execute_from_str(s, context, echo=False):
+    execute_statements(statements_from_string(s),
+                       context,
+                       echo)
+
+
+def execute_statements(asts, context, echo=False):
+    for ast in asts:
         if echo:
             print(str(ast) + literal(sym.TERMINATOR))
         ast.validate(context)
@@ -41,6 +52,7 @@ def execute_from_file(filename, context, echo=False):
         for line in ast.info():
             logger.info(line)
         ast.execute(context)
+
 
 class ExecutionError(Exception):
     pass

--- a/radb/ast.py
+++ b/radb/ast.py
@@ -306,8 +306,9 @@ class RelExpr(Node):
         query += '\nSELECT * FROM {}'.format(self.type.sql_rel())
         logger.debug('SQL generated:\n' + query)
         try:
-            print('({})'.format(', '.join(self.type.str_attr_names_and_types())))
-            context.db.execute_and_print_result(query)
+            #print('({})'.format(', '.join(self.type.str_attr_names_and_types())))
+            attrs = self.type.str_attr_names_and_types()
+            context.db.execute_and_print_result(query, attrs)
         except Exception as e:
             raise ExecutionError('SQL error in translated query:\n{}\n{}'.format(query, e)) from e
     @staticmethod
@@ -973,6 +974,6 @@ class CommandSqlexec(Command):
     def execute(self, context):
         logger.debug(self.sql)
         try:
-            context.db.execute_and_print_result(self.sql)
+            context.db.execute_and_print_result(self.sql, None)
         except Exception as e:
             raise ExecutionError('SQL error in:\n{}\n{}'.format(self.sql, e)) from e

--- a/radb/db.py
+++ b/radb/db.py
@@ -26,12 +26,13 @@ def sqltype_to_ratype(sqltype):
 
 class DB:
 
-    def __init__(self, configured, prefix='db.'):
+    def __init__(self, configured, resultprinter, prefix='db.'):
         props = { key[len(prefix):] : configured[key]\
                   for key in configured if key.startswith(prefix) }
         self.engine = create_engine(engine.url.URL.create(**props))
         self.inspector = inspect(self.engine)
         self.conn = self.engine.connect()
+        self.resultprinter = resultprinter
 
     def list(self):
         return self.inspector.get_table_names()
@@ -55,16 +56,9 @@ class DB:
             result = self.conn.execute(text(query), **kwargs)
         return result
 
-    def execute_and_print_result(self, query, **kwargs):
+    def execute_and_print_result(self, query, attrs, **kwargs):
         result = self.execute(query, **kwargs)
         if result.returns_rows:
-            print('-'*70)
-            count = 0
-            for row in result:
-                print(', '.join(str(val) for val in row))
-                count += 1
-            print('-'*70)
-            print('{} tuple{} returned'.format('no' if count == 0 else count,
-                                               '' if count == 1 else 's'))
+            print(self.resultprinter.print(result, attrs))
         else:
             print('done')

--- a/radb/parse.py
+++ b/radb/parse.py
@@ -262,6 +262,15 @@ def one_statement_from_string(s):
     ast = ASTBuilder().visit(tree)
     return ast
 
+def statements_from_string(s):
+    lexer = RALexer(InputStream(s))
+    lexer._listeners = [RAErrorListener()]
+    parser = RAParser(CommonTokenStream(lexer))
+    parser._listeners = [RAErrorListener()]
+    tree = parser.program()
+    asts = ASTBuilder().visit(tree)
+    return asts
+
 def statements_from_file(filename):
     lexer = RALexer(FileStream(filename))
     lexer._listeners = [RAErrorListener()]
@@ -372,4 +381,3 @@ class RACompleter:
             return self.matching_words[index]
         except IndexError:
             return None
-

--- a/radb/ra.py
+++ b/radb/ra.py
@@ -18,7 +18,7 @@ from radb.parse import ParsingError,\
 from radb.typesys import ValTypeChecker, TypeSysError
 from radb.views import ViewCollection
 from radb import utils
-from radb.ast import Context, ValidationError, ExecutionError, execute_from_file
+from radb.ast import Context, ValidationError, ExecutionError, execute_from_file, execute_from_str
 from radb.resultprinter import ResultPrinter
 
 import logging
@@ -111,12 +111,7 @@ def main():
     # did the user provide a single query to execute?
     if args.query:
         try:
-            ast = one_statement_from_string(args.query)
-            logger.info('statement parsed:')
-            logger.info(str(ast))
-            ast.validate(context)
-            logger.info('statement validated:')
-            ast.execute(context)
+            execute_from_str(args.query, context, echo=args.echo)
         except (ParsingError, ValidationError, ExecutionError) as e:
             logger.error(f"Query failed: {args.query}")
             logger.error(e)

--- a/radb/resultprinter.py
+++ b/radb/resultprinter.py
@@ -1,12 +1,13 @@
 import io
 from typing import override
+import csv
 
 class ResultPrinter():
 
     @classmethod
     def create(cls, outputformat):
-        if outputformat == 'radb':
-            return RADBResultPrinter()
+        if outputformat == 'default':
+            return DefaultResultPrinter()
         if outputformat == 'markdown':
             return MarkdownResultPrinter()
         if outputformat == 'org':
@@ -34,7 +35,7 @@ class ResultPrinter():
 
 
 
-class RADBResultPrinter(ResultPrinter):
+class DefaultResultPrinter(ResultPrinter):
 
     @override
     def print(self,r,attrs):
@@ -64,12 +65,10 @@ class CSVResultPrinter(ResultPrinter):
     def print(self,r, attrs):
         r = ResultPrinter.result_as_list(r)
         output = io.StringIO()
+        csvwriter = csv.writer(output)
         # write header
-        output.write(self.formatonerow(attrs))
-        count = 0
-        for row in r:
-            output.write(self.formatonerow(row))
-            count += 1
+        csvwriter.write(attrs)
+        csvwriter(r)
         return output.getvalue()
 
 

--- a/radb/resultprinter.py
+++ b/radb/resultprinter.py
@@ -11,16 +11,18 @@ class ResultPrinter():
             return MarkdownResultPrinter()
         if outputformat == 'org':
             return OrgResultPrinter()
+        if outputformat == 'csv':
+            return CSVResultPrinter()
         raise Exception(f"no result printer for {outputformat} exists!")
 
     @classmethod
     def getcolsizes(cls, r, attrs):
         colsizes = [0] * len(r[0])
         for i, v in enumerate(attrs):
-            colsizes[i] = max(colsizes[i], len(v))
+            colsizes[i] = max(colsizes[i], len(str(v)))
         for row in r:
             for i, v in enumerate(row):
-                colsizes[i] = max(colsizes[i], len(v))
+                colsizes[i] = max(colsizes[i], len(str(v)))
         return colsizes
 
     @classmethod
@@ -52,6 +54,23 @@ class RADBResultPrinter(ResultPrinter):
                                                '' if count == 1 else 's'))
         return output.getvalue()
 
+
+class CSVResultPrinter(ResultPrinter):
+
+    def formatonerow(self,row):
+        return ','.join([str(val).strip() for val in row]) + '\n'
+
+    @override
+    def print(self,r, attrs):
+        r = ResultPrinter.result_as_list(r)
+        output = io.StringIO()
+        # write header
+        output.write(self.formatonerow(attrs))
+        count = 0
+        for row in r:
+            output.write(self.formatonerow(row))
+            count += 1
+        return output.getvalue()
 
 
 class MarkdownResultPrinter(ResultPrinter):

--- a/radb/resultprinter.py
+++ b/radb/resultprinter.py
@@ -39,20 +39,18 @@ class DefaultResultPrinter(ResultPrinter):
 
     @override
     def print(self,r,attrs):
-        r = ResultPrinter.result_as_list(r)
-        colsizes = ResultPrinter.getcolsizes(r, attrs)
-        totallen = sum(colsizes) + (len(colsizes) - 1) * 2
         output = io.StringIO()
-        output.write('-'*totallen + '\n')
-        output.write(', '.join(str(val).ljust(colsizes[i]) for i,val in enumerate(attrs)) + '\n')
-        output.write('-'*totallen + '\n')
-        count = 0
-        for row in r:
-            output.write(', '.join(str(val).ljust(colsizes[i]) for i,val in enumerate(row)) + '\n')
-            count += 1
-        output.write('-'*totallen)
-        output.write('\n{} tuple{} returned'.format('no' if count == 0 else count,
-                                               '' if count == 1 else 's'))
+        output.write('({})'.format(', '.join(attrs)))
+        if r.returns_rows:
+            output.write('-'*70 + "\n")
+            count = 0
+            for row in r:
+                output.write(', '.join(str(val) for val in row) + "\n")
+                count += 1
+            output.write('-'*70 + "\n")
+            output.write('{} tuple{} returned\n'.format('no' if count == 0 else count,
+                                                        '' if count == 1 else 's'))
+
         return output.getvalue()
 
 

--- a/radb/resultprinter.py
+++ b/radb/resultprinter.py
@@ -1,0 +1,99 @@
+import io
+from typing import override
+
+class ResultPrinter():
+
+    @classmethod
+    def create(cls, outputformat):
+        if outputformat == 'radb':
+            return RADBResultPrinter()
+        if outputformat == 'markdown':
+            return MarkdownResultPrinter()
+        if outputformat == 'org':
+            return OrgResultPrinter()
+        raise Exception(f"no result printer for {outputformat} exists!")
+
+    @classmethod
+    def getcolsizes(cls, r, attrs):
+        colsizes = [0] * len(r[0])
+        for i, v in enumerate(attrs):
+            colsizes[i] = max(colsizes[i], len(v))
+        for row in r:
+            for i, v in enumerate(row):
+                colsizes[i] = max(colsizes[i], len(v))
+        return colsizes
+
+    @classmethod
+    def result_as_list(cls, r):
+        return [ x for x in r ]
+
+    def print(self, r, attrs):
+        pass
+
+
+
+class RADBResultPrinter(ResultPrinter):
+
+    @override
+    def print(self,r,attrs):
+        r = ResultPrinter.result_as_list(r)
+        colsizes = ResultPrinter.getcolsizes(r, attrs)
+        totallen = sum(colsizes) + (len(colsizes) - 1) * 2
+        output = io.StringIO()
+        output.write('-'*totallen + '\n')
+        output.write(', '.join(str(val).ljust(colsizes[i]) for i,val in enumerate(attrs)) + '\n')
+        output.write('-'*totallen + '\n')
+        count = 0
+        for row in r:
+            output.write(', '.join(str(val).ljust(colsizes[i]) for i,val in enumerate(row)) + '\n')
+            count += 1
+        output.write('-'*totallen)
+        output.write('\n{} tuple{} returned'.format('no' if count == 0 else count,
+                                               '' if count == 1 else 's'))
+        return output.getvalue()
+
+
+
+class MarkdownResultPrinter(ResultPrinter):
+
+    def formatonerow(self,row,colsizes):
+        return '| ' + ' | '.join(str(val).ljust(colsizes[i]) for i,val in enumerate(row)) + ' |\n'
+
+    def headersep(self,colsizes):
+        return '|-' + '-|-'.join("".ljust(size, '-') for i,size in enumerate(colsizes)) + '-|\n'
+
+    @override
+    def print(self,r, attrs):
+        r = ResultPrinter.result_as_list(r)
+        colsizes = ResultPrinter.getcolsizes(r, attrs)
+        output = io.StringIO()
+        # write header
+        output.write(self.formatonerow(attrs, colsizes))
+        output.write(self.headersep(colsizes))
+        count = 0
+        for row in r:
+            output.write(self.formatonerow(row, colsizes))
+            count += 1
+        return output.getvalue()
+
+class OrgResultPrinter(ResultPrinter):
+
+    def formatonerow(self,row,colsizes):
+        return '| ' + ' | '.join(str(val).ljust(colsizes[i]) for i,val in enumerate(row)) + ' |\n'
+
+    def headersep(self,colsizes):
+        return '|-' + '-+-'.join("".ljust(size, '-') for i,size in enumerate(colsizes)) + '-|\n'
+
+    @override
+    def print(self,r,attrs):
+        r = ResultPrinter.result_as_list(r)
+        colsizes = ResultPrinter.getcolsizes(r,attrs)
+        output = io.StringIO()
+        # write header
+        output.write(self.formatonerow(attrs, colsizes))
+        output.write(self.headersep(colsizes))
+        count = 0
+        for row in r:
+            output.write(self.formatonerow(row, colsizes))
+            count += 1
+        return output.getvalue()

--- a/radb/resultprinter.py
+++ b/radb/resultprinter.py
@@ -40,7 +40,7 @@ class DefaultResultPrinter(ResultPrinter):
     @override
     def print(self,r,attrs):
         output = io.StringIO()
-        output.write('({})'.format(', '.join(attrs)))
+        output.write('({})\n'.format(', '.join(attrs)))
         if r.returns_rows:
             output.write('-'*70 + "\n")
             count = 0

--- a/radb/sys.ini
+++ b/radb/sys.ini
@@ -12,8 +12,14 @@ setup.rawcodebaseurl=https://raw.githubusercontent.com/junyang/radb/master
 
 db.drivername=sqlite+pysqlite
 
+outputformat=radb
 configfile=~/.radb.ini
 historyfile=~/.radb_history
+
+outputformats=
+        radb
+        markdown
+        org
 
 default_functions=
         PLUS(number, number) -> number

--- a/radb/sys.ini
+++ b/radb/sys.ini
@@ -12,12 +12,13 @@ setup.rawcodebaseurl=https://raw.githubusercontent.com/junyang/radb/master
 
 db.drivername=sqlite+pysqlite
 
-outputformat=radb
+outputformat=default
 configfile=~/.radb.ini
 historyfile=~/.radb_history
 
 outputformats=
-        radb
+        default
+        csv
         markdown
         org
 


### PR DESCRIPTION
- the new `-q` (`--query`) option allows for better scripting

```shell
radb --query "\project_{name}(student);"
```

# Support multiple output formats

- new option `-f` for selecting an output format for query results (`markdown` or `org` tables, `csv`, and the original `radb` as the default output format.

``` shell
radb -f markdown
```